### PR TITLE
Fix mac update

### DIFF
--- a/mac/VMPC2000XL.pkgproj
+++ b/mac/VMPC2000XL.pkgproj
@@ -2378,7 +2378,7 @@
 			<key>PACKAGE_SETTINGS</key>
 			<dict>
 				<key>AUTHENTICATION</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>CONCLUSION_ACTION</key>
 				<integer>0</integer>
 				<key>FOLLOW_SYMBOLIC_LINKS</key>

--- a/mac/update/import-keyboard-mapping.sh
+++ b/mac/update/import-keyboard-mapping.sh
@@ -6,6 +6,10 @@ readonly NEW_MAPPING_PATH=$NEW_CONFIG_DIR/keys.txt
 
 [ -f "$NEW_MAPPING_PATH" ] && mv "$NEW_MAPPING_PATH" "$NEW_MAPPING_PATH.bk"
 
-[ -d "$NEW_CONFIG_DIR" ] || mkdir -p "$NEW_CONFIG_DIR"
+[ -d "$NEW_CONFIG_DIR" ] || [ 
+	mkdir -p "$NEW_CONFIG_DIR" &&
+  OWNER=$(ls -ld $OLD_MAPPING_PATH | awk '{print $3}') &&
+  chown -R $OWNER $NEW_CONFIG_DIR
+]
 
 [ -f $OLD_MAPPING_PATH ] && cp -p $OLD_MAPPING_PATH "$NEW_MAPPING_PATH"

--- a/mac/update/import-keyboard-mapping.sh
+++ b/mac/update/import-keyboard-mapping.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-
 readonly OLD_MAPPING_PATH=~/vMPC/resources/keys.txt
-readonly NEW_CONFIG_DIR='/Library/Application Support/VMPC2000XL/config'
+
+readonly NEW_CONFIG_DIR='~/Library/Application Support/VMPC2000XL/config'
 readonly NEW_MAPPING_PATH=$NEW_CONFIG_DIR/keys.txt
 
 [ -f "$NEW_MAPPING_PATH" ] && mv "$NEW_MAPPING_PATH" "$NEW_MAPPING_PATH.bk"

--- a/mac/update/import-nvram.sh
+++ b/mac/update/import-nvram.sh
@@ -4,6 +4,10 @@ readonly OLD_NVRAM_PATH=~/vMPC/resources/nvram.vmp
 readonly NEW_CONFIG_DIR='/Library/Application Support/VMPC2000XL/config'
 readonly NEW_NVRAM_PATH=$NEW_CONFIG_DIR/nvram.vmp
 
-mkdir -p "$NEW_CONFIG_DIR"
+[ -d "$NEW_CONFIG_DIR" ] || [
+	mkdir -p "$NEW_CONFIG_DIR" &&
+	OWNER=$(ls -ld $OLD_NVRAM_PATH | awk '{print $3}') &&
+	chown -R $OWNER $NEW_CONFIG_DIR
+]
 
 [ -f $OLD_NVRAM_PATH ] && cp -p $OLD_NVRAM_PATH "$NEW_NVRAM_PATH"

--- a/mac/update/import-nvram.sh
+++ b/mac/update/import-nvram.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-
 readonly OLD_NVRAM_PATH=~/vMPC/resources/nvram.vmp
-readonly NEW_CONFIG_DIR='/Library/Application Support/VMPC2000XL/config'
+
+readonly NEW_CONFIG_DIR='~/Library/Application Support/VMPC2000XL/config'
 readonly NEW_NVRAM_PATH=$NEW_CONFIG_DIR/nvram.vmp
 
 [ -d "$NEW_CONFIG_DIR" ] || [

--- a/mac/update/import-user-data.sh
+++ b/mac/update/import-user-data.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
 
 readonly OLD_DATA_PATH=~/vMPC/Stores/MPC2000XL
-readonly NEW_DATA_DIR=~/Documents/VMPC2000XL/Volumes
-readonly NEW_DATA_PATH=$NEW_DATA_DIR/MPC2000XL
+readonly NEW_DOC_PATH=~/Documents/VMPC2000XL
+readonly NEW_DATA_PARENT_PATH=~/Documents/VMPC2000XL/Volumes
+readonly NEW_DATA_PATH=~/Documents/VMPC2000XL/Volumes/MPC2000XL
 
-BK_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)
+BK_UUID=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)
 
 [ -d $NEW_DATA_PATH ] && mv $NEW_DATA_PATH $NEW_DATA_PATH-$BK_UUID
 
-mkdir -p $NEW_DATA_DIR
+[ -D $NEW_DATA_PARENT_PATH ] || [
+	mkdir -p $NEW_DATA_PARENT_PATH &&
+	OWNER=$(ls -ld $OLD_DATA_PATH | awk '{print $3}') &&
+	chown -R $OWNER $NEW_DOC_PATH
+]
 
-[ -d $OLD_DATA_PATH ] && cp -rp $OLD_DATA_PATH $NEW_DATA_DIR
+[ -d $OLD_DATA_PATH ] && cp -rp $OLD_DATA_PATH $NEW_DATA_PARENT_PATH

--- a/mac/update/import-user-data.sh
+++ b/mac/update/import-user-data.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-
 readonly OLD_DATA_PATH=~/vMPC/Stores/MPC2000XL
+
 readonly NEW_DOC_PATH=~/Documents/VMPC2000XL
 readonly NEW_DATA_PARENT_PATH=~/Documents/VMPC2000XL/Volumes
 readonly NEW_DATA_PATH=~/Documents/VMPC2000XL/Volumes/MPC2000XL

--- a/mac/update/import-vmpc-specific.sh
+++ b/mac/update/import-vmpc-specific.sh
@@ -1,9 +1,14 @@
 #!/bin/sh
 
 readonly OLD_VMPC_SPECIFIC_PATH=~/vMPC/resources/vmpc-specific.ini
+
 readonly NEW_CONFIG_DIR='/Library/Application Support/VMPC2000XL/config'
 readonly NEW_VMPC_SPECIFIC_PATH=$NEW_CONFIG_DIR/vmpc-specific.ini
 
-mkdir -p "$NEW_CONFIG_DIR"
+[ -d "$NEW_CONFIG_DIR" ] || [
+	mkdir -p "$NEW_CONFIG_DIR" &&
+	OWNER=$(ls -ld $OLD_VMPC_SPECIFIC_PATH | awk '{print $3}') &&
+	chown -R $OWNER $NEW_CONFIG_DIR
+]
 
 [ -f $OLD_VMPC_SPECIFIC_PATH ] && cp -p $OLD_VMPC_SPECIFIC_PATH "$NEW_VMPC_SPECIFIC_PATH"

--- a/mac/update/import-vmpc-specific.sh
+++ b/mac/update/import-vmpc-specific.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
-
 readonly OLD_VMPC_SPECIFIC_PATH=~/vMPC/resources/vmpc-specific.ini
 
-readonly NEW_CONFIG_DIR='/Library/Application Support/VMPC2000XL/config'
+readonly NEW_CONFIG_DIR='~/Library/Application Support/VMPC2000XL/config'
 readonly NEW_VMPC_SPECIFIC_PATH=$NEW_CONFIG_DIR/vmpc-specific.ini
 
 [ -d "$NEW_CONFIG_DIR" ] || [

--- a/mac/update/remove-previous-application.sh
+++ b/mac/update/remove-previous-application.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
-
 readonly APPLICATION_PATH=/Applications/vMPC.app
+readonly SETTINGS_PATH='~/Library/Application Support/vmpc.settings'
 
 # If the old application path exists, recursively remove it
 [ -d $APPLICATION_PATH ] && rm -rf $APPLICATION_PATH
+
+# If the old settings file exists, remove it
+[ -f $SETTINGS_PATH ] && rm $SETTINGS_PATH

--- a/mac/update/remove-previous-user-data-and-resources.sh
+++ b/mac/update/remove-previous-user-data-and-resources.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 readonly DATA_AND_RESOURCES_PATH=~/vMPC
 
 # If the old data and resources path exists, recursively remove it


### PR DESCRIPTION
We use `~/Library/Application Support` instead of `/Library/Application Support` because the latter requires elevated permissions.